### PR TITLE
Fix: Remove unnecessary pull request trigger for docker image build

### DIFF
--- a/.github/workflows/docker-image-build.yaml
+++ b/.github/workflows/docker-image-build.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - develop
-  pull_request:
 
 permissions:
   id-token: write
@@ -43,7 +42,6 @@ jobs:
         run: |
           echo "${{ steps.semantic_release.outputs.new_release_version }}"
           echo "${{ steps.generate_tag.outputs.sha }}"
-
 
   release:
     needs: build


### PR DESCRIPTION
Removed the pull request trigger from the Docker image build workflow. This prevents unnecessary image builds on pull requests, reducing CI load and resource usage.