### PR TITLE
feat: Add homolog and develop branches to release process

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -1,6 +1,8 @@
 {
   "branches": [
-    "main"
+    "main",
+    "homolog",
+    "develop"
   ],
   "plugins": [
     "@semantic-release/commit-analyzer",


### PR DESCRIPTION
Enable automated releases on `homolog` and `develop` branches in addition to `main`. This allows for seamless release management across different environments.