### PR TITLE
feat: Remove unused branch configuration

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -1,7 +1,5 @@
 {
   "branches": [
-    "main",
-    "homolog",
     "develop"
   ],
   "plugins": [


### PR DESCRIPTION
The `homolog` branch configuration has been removed from the `releaserc` file as it is no longer necessary for the release process. This simplifies the configuration and streamlines the release pipeline.