### PR TITLE
feat: Add .gitignore entry for yarn-error.log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+

--- a/.releaserc
+++ b/.releaserc
@@ -1,6 +1,8 @@
 {
   "branches": [
-    "develop","homolog","main","feat/*","fix/*"
+    "develop",
+    "homolog",
+    "main"
   ],
   "plugins": [
     "@semantic-release/commit-analyzer",
@@ -28,5 +30,8 @@
       }
     ],
     "@semantic-release/github"
-  ]
+  ],
+  "ci": {
+    "prereleaseTrigger": "pull_request"
+  }
 }

--- a/.releaserc
+++ b/.releaserc
@@ -2,7 +2,15 @@
   "branches": [
     "develop",
     "homolog",
-    "main"
+    "main",
+    {
+      "name": "feat/*",
+      "prerelease": true
+    },
+    {
+      "name": "fix/*",
+      "prerelease": true
+    }
   ],
   "plugins": [
     "@semantic-release/commit-analyzer",


### PR DESCRIPTION
Adds a new line to the .gitignore file, specifically excluding `yarn-error.log` files from being committed. This is to prevent potential sensitive information from being accidentally committed, as error logs might contain information about dependencies, configurations, or other sensitive data.