### PR TITLE
fix: Use self-hosted runner for CD workflow

### DIFF
--- a/.github/workflows/docker-image-build.yaml
+++ b/.github/workflows/docker-image-build.yaml
@@ -53,5 +53,6 @@ jobs:
           cat VERSIONS
 
   cd:
+    runs-on: self-hosted
     needs: [release]
     uses: renatoDev0ps/github-to-dockerhub/.github/workflows/docker-image-deploy.yaml@develop


### PR DESCRIPTION
The CD workflow was previously running on a shared runner, which could lead to potential performance issues and resource constraints.  This commit switches the workflow to run on a self-hosted runner, ensuring dedicated resources and improved performance.