### PR TITLE
fix: Update deployment workflow trigger

### DIFF
--- a/.github/workflows/docker-image-build.yaml
+++ b/.github/workflows/docker-image-build.yaml
@@ -51,8 +51,3 @@ jobs:
           version=$(jq -r '.version' "./package.json") > VERSIONS
           echo $version 
           cat VERSIONS
-
-  cd:
-    runs-on: self-hosted
-    needs: [release]
-    uses: renatoDev0ps/github-to-dockerhub/.github/workflows/docker-image-deploy.yaml@develop

--- a/.github/workflows/docker-image-deploy.yaml
+++ b/.github/workflows/docker-image-deploy.yaml
@@ -2,7 +2,10 @@ name: "[CD] Deploy to Server"
 
 on:
   workflow_dispatch:
-  workflow_call:
+  workflow_run:
+    workflows: ["[CI] Pipeline"]
+    types:
+      - completed
 
 jobs:
   deploy:


### PR DESCRIPTION
Updated the deployment workflow to use `workflow_run` instead of the deprecated `workflow_call` to ensure reliable and consistent deployment following successful CI pipeline execution.